### PR TITLE
Add bug report and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug Report
+description: Something is broken in the plugin
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: search existing issues and make sure you're on the **latest plugin version**.
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin Version
+      placeholder: "e.g. 1.4.2"
+    validations:
+      required: true
+
+  - type: input
+    id: obsidian-version
+    attributes:
+      label: Obsidian Version
+      placeholder: "e.g. 1.6.3"
+    validations:
+      required: true
+
+  - type: input
+    id: installer-version
+    attributes:
+      label: Obsidian Installer Version
+      description: Found in Settings → About → Installer version. This matters — runtime bugs are often installer-related.
+      placeholder: "e.g. 1.1.16"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Android
+        - iOS / iPadOS
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Be specific. "It doesn't work" is not a bug report.
+      placeholder: "When I do X, Y happens instead of Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Open a note
+        2. Run command '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: console-errors
+    attributes:
+      label: Console Errors
+      description: Open the developer console (Ctrl+Shift+I / Cmd+Opt+I), reproduce the bug, paste any errors here. If there are none, say so.
+      render: bash
+
+  - type: dropdown
+    id: restricted-mode
+    attributes:
+      label: Does the bug occur with all other plugins disabled?
+      description: Helps rule out plugin conflicts.
+      options:
+        - "Yes"
+        - "No"
+        - "Didn't test"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Anything Else?
+      description: Screenshots, screen recordings, related issues, vault setup details — whatever's relevant.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest a new feature or improvement for the plugin
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting: search existing issues to make sure this hasn't already been requested or discussed.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the workflow friction or limitation you're running into. Don't jump straight to your solution yet.
+      placeholder: "When I try to do X, I have to Y which is annoying because..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see added or changed? Be as specific as you can.
+      placeholder: "It would help if the plugin could..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Any workarounds you're currently using, or other approaches you've thought about.
+      placeholder: "I've tried X but it falls short because..."
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: How impactful would this be for your workflow?
+      options:
+        - Nice to have
+        - Would use it regularly
+        - Blocking my use of the plugin
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I've searched existing issues and this hasn't been requested before
+          required: true
+        - label: This is specific to this plugin, not a general Obsidian feature request
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, links to similar features in other tools — anything that helps illustrate the request.


### PR DESCRIPTION
Hey, after you recently resolved a bug that I encountered with the plugin I wanted to give back. Here's a start with some basic issue templates to ensure you get the necessary info when people submit bug reports or feature requests. I can also help you with automating any manual steps in the build/release process if you need/want. 